### PR TITLE
Add xml dependencies required by tastypie

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ gunicorn==19.6.0
 django-tastypie==0.13.3
 python-dateutil==2.6.0
 python-mimeparse==1.6.0
+defusedxml==0.5.0
+lxml==4.0.0


### PR DESCRIPTION
Fixes error on http://scipion.i2pc.es/report_protocols/api calls: 

`Usage of the XML aspects requires lxml and defusedxml`