### PR TITLE
Add download to admin panel

### DIFF
--- a/web/admin.py
+++ b/web/admin.py
@@ -1,0 +1,18 @@
+from django.contrib import admin
+from models import Download
+
+class DownloadAdmin(admin.ModelAdmin):
+    list_display = ('fullName', 'organization', 'country', 'email', 'subscription', 'version', 'platform')
+    search_fields = ('fullName', 'organization', 'country', 'email', 'platform')
+    ordering = ("creation",)
+
+    def has_add_permission(self, request):
+        return False
+
+    def has_change_permission(self, request, obj=None):
+        return (False if obj else True)
+
+    def has_delete_permission(self, request, obj=None):
+        return True
+
+admin.site.register(Download, DownloadAdmin)

--- a/web/admin.py
+++ b/web/admin.py
@@ -2,9 +2,9 @@ from django.contrib import admin
 from models import Download
 
 class DownloadAdmin(admin.ModelAdmin):
-    list_display = ('fullName', 'organization', 'country', 'email', 'subscription', 'version', 'platform')
-    search_fields = ('fullName', 'organization', 'country', 'email', 'platform')
-    ordering = ("creation",)
+    list_display = ("fullName", "organization", "country", "subscription", "version", "platform", "creation")
+    search_fields = ("fullName", "organization", "country", "email", "platform")
+    ordering = ("-creation",)
 
     def has_add_permission(self, request):
         return False


### PR DESCRIPTION
@pconesa This adds the download table to the admin panel as we discussed yesterday. Kudos to @tokland for the quick fix. Any problem, give us a shout!

![screenshot from 2017-11-30 13-09-10](https://user-images.githubusercontent.com/24643/33430122-a7589d2e-d5cf-11e7-934c-4bf46118a24e.png)

- Search bar added.
- Add actions disabled.
- Edit actions disabled.
- Delete actions enabled.